### PR TITLE
Add social tables migration

### DIFF
--- a/MIGRATION_INSTRUCTIONS.md
+++ b/MIGRATION_INSTRUCTIONS.md
@@ -11,7 +11,7 @@ You need to manually apply the migration to create the profiles table. Follow th
 2. Select your project
 3. Navigate to the "SQL Editor" in the left sidebar
 
-### Step 2: Execute the Migration
+### Step 2: Execute the Profiles Migration
 Copy and paste the following SQL code into the SQL Editor and click "Run":
 
 ```sql
@@ -130,7 +130,20 @@ CREATE TRIGGER update_profiles_updated_at
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 ```
 
-### Step 3: Create Storage Bucket (Optional)
+### Step 3: Execute the Social Tables Migration
+Run the following SQL to create the additional tables used by the application:
+
+```sql
+/*
+  # Add Social Accounts, Posts, and Messages tables
+*/
+
+-- Copy the contents of `supabase/migrations/20250614173000_expanded_social_schema.sql`
+-- into the SQL editor and run it. This will create the `social_accounts`,
+-- `posts`, and `messages` tables along with row level security policies.
+```
+
+### Step 4: Create Storage Bucket (Optional)
 If you plan to use avatar uploads, also create a storage bucket:
 
 1. Go to "Storage" in the left sidebar
@@ -138,7 +151,7 @@ If you plan to use avatar uploads, also create a storage bucket:
 3. Name it `profiles`
 4. Make it public if you want avatars to be publicly accessible
 
-### Step 4: Configure Authentication Settings
+### Step 5: Configure Authentication Settings
 To fix OTP issues:
 
 1. Go to "Authentication" > "Settings" in your Supabase dashboard

--- a/supabase/migrations/20250614173000_expanded_social_schema.sql
+++ b/supabase/migrations/20250614173000_expanded_social_schema.sql
@@ -1,0 +1,117 @@
+/*
+  # Add Social Accounts, Posts, and Messages tables
+
+  1. New Tables
+    - `social_accounts`
+      - `id` (uuid, primary key, default uuid_generate_v4())
+      - `profile_id` (uuid, references profiles)
+      - `provider` (text)
+      - `account_url` (text)
+      - `verified` (boolean)
+      - `created_at` (timestamp)
+      - `updated_at` (timestamp)
+
+    - `posts`
+      - `id` (uuid, primary key, default uuid_generate_v4())
+      - `profile_id` (uuid, references profiles)
+      - `title` (text)
+      - `content` (text)
+      - `media_url` (text)
+      - `created_at` (timestamp)
+      - `updated_at` (timestamp)
+
+    - `messages`
+      - `id` (uuid, primary key, default uuid_generate_v4())
+      - `sender_id` (uuid, references profiles)
+      - `receiver_id` (uuid, references profiles)
+      - `content` (text)
+      - `read` (boolean)
+      - `created_at` (timestamp)
+
+  2. Security
+    - Enable RLS on all tables
+    - Policies for users to manage their own records
+    - Allow reading public posts and profiles
+
+  3. Functions
+    - Update timestamp on changes for tables with `updated_at`
+*/
+
+-- Social Accounts table
+CREATE TABLE IF NOT EXISTS social_accounts (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  profile_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  provider text CHECK (provider IN ('instagram', 'facebook', 'linkedin', 'twitter', 'google')),
+  account_url text NOT NULL,
+  verified boolean DEFAULT false,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (profile_id, provider)
+);
+
+-- Posts table
+CREATE TABLE IF NOT EXISTS posts (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  profile_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  title text,
+  content text,
+  media_url text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Messages table
+CREATE TABLE IF NOT EXISTS messages (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  sender_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  receiver_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  content text NOT NULL,
+  read boolean DEFAULT false,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE social_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE posts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE messages ENABLE ROW LEVEL SECURITY;
+
+-- Social Accounts policies
+CREATE POLICY "Users can read social accounts" ON social_accounts
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Users manage own social accounts" ON social_accounts
+  FOR ALL TO authenticated USING (auth.uid() = profile_id) WITH CHECK (auth.uid() = profile_id);
+
+-- Posts policies
+CREATE POLICY "Users can read posts" ON posts
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Users manage own posts" ON posts
+  FOR ALL TO authenticated USING (auth.uid() = profile_id) WITH CHECK (auth.uid() = profile_id);
+
+-- Messages policies
+CREATE POLICY "Users can read own messages" ON messages
+  FOR SELECT TO authenticated USING (auth.uid() = sender_id OR auth.uid() = receiver_id);
+CREATE POLICY "Users can send messages" ON messages
+  FOR INSERT TO authenticated WITH CHECK (auth.uid() = sender_id);
+CREATE POLICY "Users can update own messages" ON messages
+  FOR UPDATE TO authenticated USING (auth.uid() = sender_id OR auth.uid() = receiver_id);
+
+-- Function to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to update updated_at on social_accounts changes
+DROP TRIGGER IF EXISTS update_social_accounts_updated_at ON social_accounts;
+CREATE TRIGGER update_social_accounts_updated_at
+  BEFORE UPDATE ON social_accounts
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Trigger to update updated_at on posts changes
+DROP TRIGGER IF EXISTS update_posts_updated_at ON posts;
+CREATE TRIGGER update_posts_updated_at
+  BEFORE UPDATE ON posts
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- create Supabase migration for social tables (social_accounts, posts, messages)
- update migration instructions to include new step for running this migration

## Testing
- `npm install`
- `npm run build` *(fails: Type error in ProfileScreen)*

------
https://chatgpt.com/codex/tasks/task_e_684d68b90ee08333aa4aaaf470fa6898